### PR TITLE
feat(macbook): add and enable typeless module

### DIFF
--- a/machines/macbook/default.nix
+++ b/machines/macbook/default.nix
@@ -216,7 +216,6 @@
       google-drive.enable = true;
       google-japanese-ime.enable = true;
       istat-menus.enable = true;
-      thaw.enable = true;
       karabiner-elements.enable = true;
       leader-key.enable = false;
       logi-options-plus.enable = true;
@@ -225,7 +224,9 @@
       sanebar.enable = false;
       spotify.enable = true;
       textsniper.enable = true;
+      thaw.enable = true;
       the-unarchiver.enable = true;
+      typeless.enable = true;
       yoink.enable = true;
       zappy.enable = true;
     };

--- a/modules/utilities/typeless/default.nix
+++ b/modules/utilities/typeless/default.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.modules.utilities.typeless;
+in
+{
+  options.modules.utilities.typeless = {
+    enable = mkEnableOption "AI voice dictation that turns speech into polished text";
+  };
+
+  config = mkIf cfg.enable {
+    homebrew = mkIf (config.modules.system.homebrew.enable or false) {
+      casks = [ "typeless" ];
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- `modules/utilities/typeless` モジュールを新規追加
- macbook で `modules.utilities.typeless.enable = true` を設定し有効化
- あわせて `thaw.enable` の位置をアルファベット順に整理

## Test plan
- [x] `just dry-run` が成功すること
- [x] `darwin-rebuild switch --flake .#macbook` 後に typeless が動作すること