### PR TITLE
feat(vcs): add worktrunk module for Git worktree management

### DIFF
--- a/machines/macbook/default.nix
+++ b/machines/macbook/default.nix
@@ -104,6 +104,7 @@
             memory = "4GiB";
           };
         };
+        worktrunk.enable = true;
       };
     };
 

--- a/modules/development/vcs/default.nix
+++ b/modules/development/vcs/default.nix
@@ -13,5 +13,6 @@
     ./github
     ./pre-commit
     ./workmux
+    ./worktrunk
   ];
 }

--- a/modules/development/vcs/worktrunk/default.nix
+++ b/modules/development/vcs/worktrunk/default.nix
@@ -1,0 +1,37 @@
+{
+  config,
+  pkgs,
+  lib,
+  username,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.modules.development.vcs.worktrunk;
+in
+{
+  options.modules.development.vcs.worktrunk = {
+    enable = mkEnableOption "Enable worktrunk - CLI for Git worktree management";
+    enableZshIntegration = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable zsh shell integration so `wt switch` can change directories";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    homebrew = mkIf (config.modules.system.homebrew.enable or false) {
+      brews = [ "worktrunk" ];
+    };
+
+    home-manager.users.${username} = mkIf cfg.enableZshIntegration {
+      programs.zsh.initContent = lib.mkAfter ''
+        if command -v wt >/dev/null 2>&1; then
+          eval "$(wt config shell init zsh)"
+        fi
+      '';
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Adds new module \`modules/development/vcs/worktrunk\` providing the \`worktrunk\` Homebrew brew
- Optional zsh shell integration (default on) wires \`eval "\$(wt config shell init zsh)"\` so \`wt switch\` can change directories
- Enabled on macbook

## Test plan
- [x] \`nix build .#darwinConfigurations.macbook.system --dry-run\` passes
- [ ] After merge: \`just switch\`, then \`wt --version\` and \`wt switch\` work in zsh