### PR TITLE
chore(workmux): comment out worktree_dir to use default location

### DIFF
--- a/modules/development/vcs/workmux/config.yaml
+++ b/modules/development/vcs/workmux/config.yaml
@@ -1,6 +1,6 @@
 base_branch: origin/main
 nerdfont: true
-worktree_dir: .worktrees
+# worktree_dir: .worktrees
 
 pre_add:
   - git fetch origin


### PR DESCRIPTION
## Summary
Comments out the explicit \`worktree_dir: .worktrees\` setting in workmux \`config.yaml\` so workmux falls back to its default worktree location.

## Test plan
- [ ] After merge + \`just switch\`: \`workmux\` add a worktree and confirm it lands in the default location