### PR TITLE
chore(tmux): change prefix to C-Space and tighten escape/repeat timings

### DIFF
--- a/modules/terminal/tmux/default.nix
+++ b/modules/terminal/tmux/default.nix
@@ -41,18 +41,21 @@ in
       baseIndex = 1;
       clock24 = true;
       customPaneNavigationAndResize = true;
-      escapeTime = 1;
+      escapeTime = 0;
       focusEvents = true;
       historyLimit = 10000;
       keyMode = "vi";
       mouse = true;
-      prefix = "C-a";
+      prefix = "C-Space";
       sensibleOnTop = true;
       shell = "${pkgs.zsh}/bin/zsh";
       terminal = "tmux-256color";
       extraConfig = ''
         # 設定ファイルをリロードする
         bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded!"
+
+        # 連打系（resize-pane など）の repeat 受付時間を短く
+        set -g repeat-time 300
 
         # | でペインを縦に分割する
         bind | split-window -h


### PR DESCRIPTION
## Summary
- Prefix: \`C-a\` → \`C-Space\` (avoids conflict with shell \`Ctrl-A\` go-to-line-start)
- \`escapeTime\` 1 → 0 (snappier vim mode in tmux panes)
- Adds \`set -g repeat-time 300\` to shorten the repeat window for keys like resize-pane

## Test plan
- [x] \`nix build .#darwinConfigurations.macbook.system --dry-run\` passes
- [ ] After merge + \`just switch\`: open a new tmux session, confirm \`C-Space\` triggers prefix and \`Esc\` in vim feels instant