### PR TITLE
feat(machines): support machine-local environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ result
 
 # machines
 # machines/work/config.nix
+machines/*/env.local

--- a/machines/work/env.local.example
+++ b/machines/work/env.local.example
@@ -1,0 +1,12 @@
+# machines/work/env.local — machine-local environment variables
+#
+# Copy this file to `env.local` (same directory) and fill in real values.
+# `env.local` is git-ignored, so secrets stay on this machine only.
+# It is sourced by zsh at shell startup (see machines/work/overrides.nix).
+#
+#   cp machines/work/env.local.example machines/work/env.local
+
+# Route Claude Code through Vertex AI
+export CLAUDE_CODE_USE_VERTEX=1
+export ANTHROPIC_VERTEX_PROJECT_ID="your-gcp-project-id"
+export CLOUD_ML_REGION="asia-northeast1"

--- a/machines/work/overrides.nix
+++ b/machines/work/overrides.nix
@@ -22,4 +22,13 @@
     };
   };
 
+  # Machine-local environment variables (git-ignored, not Nix-managed).
+  # Sourced last (mkAfter) so this machine-specific layer can override values
+  # set by the generic config. See machines/work/env.local.example for the format.
+  home-manager.users.${username}.programs.zsh.initContent =
+    lib.mkIf config.modules.terminal.zsh.enable (
+      lib.mkAfter ''
+        [ -f ~/.dotfiles/machines/work/env.local ] && source ~/.dotfiles/machines/work/env.local
+      ''
+    );
 }


### PR DESCRIPTION
## 概要

マシンごとに git 管理外の環境変数を設定できるようにする。仕事用PCでのみ Claude Code を Vertex AI 経由にする等、特定マシン限定の環境変数を他マシンに影響させずに持てる。

## 設計

- 環境変数を **Nix の評価に乗せない**（シェル起動時に source）方式。これにより flake の purity を維持し `--impure` 不要。
- 依存方向は **machine → 汎用** を維持。汎用 `.zshrc` は `machines/` を一切知らず、`machines/work/overrides.nix` が自分の `env.local` を `programs.zsh.initContent` に `mkAfter` で追記する。
- 実値ファイル `machines/*/env.local` は `.gitignore` 対象で git の index にも入らない。

## 変更内容

| ファイル | 変更 |
|---|---|
| `.gitignore` | `machines/*/env.local` を追加 |
| `machines/work/overrides.nix` | zsh 有効時に `machines/work/env.local` を source する設定を追記 |
| `machines/work/env.local.example` | git 管理のサンプル（Vertex AI 設定例付き、新規） |

## 利用手順（仕事用PC）

```
cp machines/work/env.local.example machines/work/env.local
# env.local に実値を記入
just switch
```

## 検証

- `env.local` が gitignore 対象 / `env.local.example` は追跡されることを確認
- `overrides.nix` の構文チェック・`nix fmt` 整形済み
- 注: `darwin-rebuild --dry-run .#work` は `machines/work/config.nix` が placeholder のため別Macからは実行不可。ビルド検証は実機で行う。