### PR TITLE
feat(claude-code): support machine-local settings.json override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ result
 # machines
 # machines/work/config.nix
 machines/*/env.local
+machines/*/claude-code/settings.json

--- a/machines/work/claude-code/settings.json.example
+++ b/machines/work/claude-code/settings.json.example
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(codex exec:*)"
+    ],
+    "defaultMode": "auto"
+  },
+  "enableAllProjectMcpServers": true,
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "permission_prompt|elicitation_dialog",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status waiting"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status working"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status done"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "workmux set-window-status working"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y ccstatusline@latest --hook"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y ccstatusline@latest --hook"
+          }
+        ]
+      }
+    ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "npx -y ccstatusline@latest",
+    "padding": 0
+  },
+  "enabledPlugins": {
+    "claude-mem@thedotmack": true,
+    "document-skills@anthropic-agent-skills": true,
+    "example-skills@anthropic-agent-skills": true
+  },
+  "extraKnownMarketplaces": {
+    "anthropic-agent-skills": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/skills"
+      }
+    },
+    "thedotmack": {
+      "source": {
+        "source": "github",
+        "repo": "thedotmack/claude-mem"
+      }
+    }
+  },
+  "language": "japanese",
+  "skipAutoPermissionPrompt": true,
+  "theme": "dark-ansi",
+  "editorMode": "vim"
+}

--- a/machines/work/default.nix
+++ b/machines/work/default.nix
@@ -17,6 +17,12 @@
     ai = {
       chatgpt.enable = false;
       claude.enable = true;
+      claude-code = {
+        enable = true;
+        # Machine-local settings.json (git-ignored, edited live by Claude Code).
+        # Seeded from machines/work/claude-code/settings.json.example.
+        settingsSource = "machines/work/claude-code/settings.json";
+      };
       gemini.enable = true;
       perplexity.enable = false;
     };

--- a/modules/ai/claude-code/default.nix
+++ b/modules/ai/claude-code/default.nix
@@ -13,7 +13,19 @@ let
   dotfilesPath = "/Users/${username}/.dotfiles";
 in
 {
-  options.modules.ai.claude-code.enable = mkEnableOption "Claude Code CLI and dotfiles";
+  options.modules.ai.claude-code = {
+    enable = mkEnableOption "Claude Code CLI and dotfiles";
+
+    settingsSource = mkOption {
+      type = types.str;
+      default = "modules/ai/claude-code/settings.json";
+      description = ''
+        Path to settings.json, relative to the dotfiles repository root.
+        Defaults to the shared settings; override per-machine (in the machine's
+        default.nix) to point at a machine-local (git-ignored) settings.json.
+      '';
+    };
+  };
 
   config = mkIf cfg.enable {
     nixpkgs.config.allowUnfreePredicate =
@@ -31,7 +43,7 @@ in
       {
         home.file = {
           ".claude/settings.json".source =
-            config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/modules/ai/claude-code/settings.json";
+            config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/${cfg.settingsSource}";
           ".claude/CLAUDE.md".source =
             config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/modules/ai/claude-code/CLAUDE.md";
           ".config/ccstatusline/settings.json".source =


### PR DESCRIPTION
## 概要
Claude Code の `settings.json` をマシン毎に切り替え可能にする。共通設定をデフォルトとしつつ、work マシンなど特定環境では専用の `settings.json`（会社用 marketplace 等を含む）を使えるようにする。

## 背景
- Claude Code は `~/.claude/settings.json` を read-modify-write でライブ編集する（`/config`、`/plugin` 等）
- そのため out-of-store symlink の維持が必須で、「共通＋差分のレイヤーマージ」は原理的に不可
- 現実解として **symlink の参照先をマシン毎に切り替える**方式（マシン毎フルファイル）を採用

## 変更内容
| ファイル | 変更 |
|---|---|
| `modules/ai/claude-code/default.nix` | `settingsSource` オプション追加（**リポジトリルートからの相対パス**、デフォルト = 共通 `settings.json`）。symlink 先をモジュール側で `dotfilesPath` を前置して構築 |
| `machines/work/default.nix` | `ai` ブロックに `claude-code` を追加（`enable = true` + `settingsSource` を work 専用パスに設定） |
| `.gitignore` | `machines/*/claude-code/settings.json` を追加（git-ignored、ローカル専用） |
| `machines/work/claude-code/settings.json.example` | 共通 `settings.json` のコピー（seed 用テンプレート） |

## 仕組み
- `settingsSource` はリポジトリルートからの相対パス。モジュール側で `${dotfilesPath}/${cfg.settingsSource}` として絶対パス化し `mkOutOfStoreSymlink` に渡す
- **macbook / macmini**: `settingsSource` 未設定 → 共通 `modules/ai/claude-code/settings.json` を symlink（現状維持）
- **work**: `default.nix` で `settingsSource = "machines/work/claude-code/settings.json"` → git-ignored の専用ファイルを symlink。Claude Code が直接ライブ編集可能
- `settingsSource` は `modules.ai.claude-code.*` のオプションなので、モジュール enable と同じ `default.nix` に置く（依存方向 = machine → module）

## work マシンでの利用手順
```bash
cp machines/work/claude-code/settings.json.example machines/work/claude-code/settings.json
darwin-rebuild switch --flake .#work
```

## 検証
- `nix build .#darwinConfigurations.macbook.system` → 成功
- work は当マシンでは `config.nix` の username が placeholder のため評価不可（既存制約、本変更とは無関係）