### PR TITLE
chore(tmux): change prefix key back to C-a

### DIFF
--- a/modules/terminal/tmux/default.nix
+++ b/modules/terminal/tmux/default.nix
@@ -46,7 +46,7 @@ in
       historyLimit = 10000;
       keyMode = "vi";
       mouse = true;
-      prefix = "C-Space";
+      prefix = "C-a";
       sensibleOnTop = true;
       shell = "${pkgs.zsh}/bin/zsh";
       terminal = "tmux-256color";


### PR DESCRIPTION
tmux の prefix キーを C-Space から C-a に戻す。