### PR TITLE
feat(ai): introduce APM for declarative plugin/skill/MCP management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ result
 # machines/work/config.nix
 machines/*/env.local
 machines/*/claude-code/settings.json
+
+# APM dependencies
+apm_modules/

--- a/Justfile
+++ b/Justfile
@@ -29,3 +29,19 @@ show:
 
 modules:
     ./scripts/enable-module.sh {{MACHINE}}
+
+# Sync apm packages (read-only; fails on lockfile drift)
+apm-sync:
+    apm install --frozen -g
+
+# Refresh apm dependencies and regenerate lockfile (commit the diff)
+apm-update:
+    apm update
+
+# Show outdated apm dependencies
+apm-outdated:
+    apm outdated -g
+
+# Audit apm installation integrity and drift
+apm-audit:
+    apm audit

--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,7 @@ dry-run:
 
 switch:
     sudo darwin-rebuild switch --flake .#{{MACHINE}}
+    just apm-sync
 
 check:
     nix flake check

--- a/Justfile
+++ b/Justfile
@@ -8,7 +8,7 @@ dry-run:
 
 switch:
     sudo darwin-rebuild switch --flake .#{{MACHINE}}
-    just apm-sync
+    # just apm-sync
 
 check:
     nix flake check

--- a/machines/macbook/default.nix
+++ b/machines/macbook/default.nix
@@ -15,6 +15,7 @@
   # Enable modules using actual directory structure paths
   modules = {
     ai = {
+      apm.enable = true;
       chatgpt.enable = true;
       claude.enable = true;
       claude-code.enable = true;

--- a/modules/ai/apm/.gitignore
+++ b/modules/ai/apm/.gitignore
@@ -1,0 +1,3 @@
+
+# APM dependencies
+apm_modules/

--- a/modules/ai/apm/.gitignore
+++ b/modules/ai/apm/.gitignore
@@ -1,3 +1,0 @@
-
-# APM dependencies
-apm_modules/

--- a/modules/ai/apm/apm.lock.yaml
+++ b/modules/ai/apm/apm.lock.yaml
@@ -1,40 +1,7 @@
 lockfile_version: '1'
-generated_at: '2026-05-15T08:45:52.167762+00:00'
-apm_version: 0.13.0
+generated_at: '2026-05-21T13:15:55.981022+00:00'
+apm_version: 0.14.0
 dependencies:
-- repo_url: anthropics/claude-plugins-official
-  host: github.com
-  resolved_commit: 1a2f18b05cf5652fd25403e8d229fc884fb84103
-  virtual_path: plugins/ralph-loop
-  is_virtual: true
-  package_type: marketplace_plugin
-  deployed_files:
-  - .claude/commands/cancel-ralph.md
-  - .claude/commands/help.md
-  - .claude/commands/ralph-loop.md
-  - .config/opencode/commands/cancel-ralph.md
-  - .config/opencode/commands/help.md
-  - .config/opencode/commands/ralph-loop.md
-  - .cursor/commands/cancel-ralph.md
-  - .cursor/commands/help.md
-  - .cursor/commands/ralph-loop.md
-  - .gemini/commands/cancel-ralph.toml
-  - .gemini/commands/help.toml
-  - .gemini/commands/ralph-loop.toml
-  deployed_file_hashes:
-    .claude/commands/cancel-ralph.md: sha256:942236042e91987d23f140703d9e81a097cc6c3d73fb09c32cbce3d358745ad8
-    .claude/commands/help.md: sha256:414a3189d727186194aab7c8a60af93daa35c3d6995406a1697e4c66b0efdcd9
-    .claude/commands/ralph-loop.md: sha256:e560af6864dd5554ab26464cb526507e2b836117d468ca9c403fb6d5c674a900
-    .config/opencode/commands/cancel-ralph.md: sha256:942236042e91987d23f140703d9e81a097cc6c3d73fb09c32cbce3d358745ad8
-    .config/opencode/commands/help.md: sha256:414a3189d727186194aab7c8a60af93daa35c3d6995406a1697e4c66b0efdcd9
-    .config/opencode/commands/ralph-loop.md: sha256:e560af6864dd5554ab26464cb526507e2b836117d468ca9c403fb6d5c674a900
-    .cursor/commands/cancel-ralph.md: sha256:942236042e91987d23f140703d9e81a097cc6c3d73fb09c32cbce3d358745ad8
-    .cursor/commands/help.md: sha256:414a3189d727186194aab7c8a60af93daa35c3d6995406a1697e4c66b0efdcd9
-    .cursor/commands/ralph-loop.md: sha256:e560af6864dd5554ab26464cb526507e2b836117d468ca9c403fb6d5c674a900
-    .gemini/commands/cancel-ralph.toml: sha256:1bdb0a132597482657d88e6dca6f783eb85d58a92b491c312d620f7807f6435d
-    .gemini/commands/help.toml: sha256:c6c04acfb35a2b2f99b6e6972ed99f20be084a697bbedaeaff8b71f6647230a3
-    .gemini/commands/ralph-loop.toml: sha256:6f24c1c80458301677dd017941fe0b8071e2fbb9119ff8f6dc1deb3319e8f6fc
-  content_hash: sha256:505ef90f057b672ca418a7ba10da05be195d28b7089063beed4c614a08fb3c07
 - repo_url: anthropics/skills
   host: github.com
   resolved_commit: f458cee31a7577a47ba0c9a101976fa599385174
@@ -75,6 +42,44 @@ dependencies:
   - .claude/skills/webapp-testing
   - .claude/skills/xlsx
   content_hash: sha256:91959dd47c219df6af45ed9d3f4be4302b00041e447254fdda0c51767b24e57b
+- repo_url: currents-dev/playwright-best-practices-skill
+  host: github.com
+  resolved_commit: ef329e7e65149918e1ff0eed2cf7d2e6e6f9eb5b
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/playwright-best-practices-skill
+  - .claude/skills/playwright-best-practices-skill
+  content_hash: sha256:4a2c8b6165b46914f587131006256040286185918e6ee5903ad070087cdb53bc
+- repo_url: shadcn-ui/ui
+  host: github.com
+  resolved_commit: 731e6dd8a2c9981b5d419f7dcf5b6476a69d288c
+  virtual_path: skills/shadcn
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/shadcn
+  - .claude/skills/shadcn
+  content_hash: sha256:e9d76d55c14a21546595524cdc44466d191c0da4e183298949ae881b8b6d5e24
+- repo_url: vercel-labs/agent-skills
+  host: github.com
+  resolved_commit: 7defe2d03c5fa8e39b63b12648c1fa10131b422a
+  virtual_path: skills/react-best-practices
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/react-best-practices
+  - .claude/skills/react-best-practices
+  content_hash: sha256:74f142d28d360d78e8bac4f239a84c87f0ced9015729bc72b5458d82ff45b015
+- repo_url: vercel-labs/next-skills
+  host: github.com
+  resolved_commit: dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9
+  virtual_path: skills/next-best-practices
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/next-best-practices
+  - .claude/skills/next-best-practices
+  content_hash: sha256:4bf1b21f7a66848642c150cab284f24c004ad6da0f717eed4fe9db74eaa6b6a8
 mcp_servers:
 - io.github.github/github-mcp-server
 mcp_configs:

--- a/modules/ai/apm/apm.lock.yaml
+++ b/modules/ai/apm/apm.lock.yaml
@@ -1,0 +1,83 @@
+lockfile_version: '1'
+generated_at: '2026-05-15T08:45:52.167762+00:00'
+apm_version: 0.13.0
+dependencies:
+- repo_url: anthropics/claude-plugins-official
+  host: github.com
+  resolved_commit: 1a2f18b05cf5652fd25403e8d229fc884fb84103
+  virtual_path: plugins/ralph-loop
+  is_virtual: true
+  package_type: marketplace_plugin
+  deployed_files:
+  - .claude/commands/cancel-ralph.md
+  - .claude/commands/help.md
+  - .claude/commands/ralph-loop.md
+  - .config/opencode/commands/cancel-ralph.md
+  - .config/opencode/commands/help.md
+  - .config/opencode/commands/ralph-loop.md
+  - .cursor/commands/cancel-ralph.md
+  - .cursor/commands/help.md
+  - .cursor/commands/ralph-loop.md
+  - .gemini/commands/cancel-ralph.toml
+  - .gemini/commands/help.toml
+  - .gemini/commands/ralph-loop.toml
+  deployed_file_hashes:
+    .claude/commands/cancel-ralph.md: sha256:942236042e91987d23f140703d9e81a097cc6c3d73fb09c32cbce3d358745ad8
+    .claude/commands/help.md: sha256:414a3189d727186194aab7c8a60af93daa35c3d6995406a1697e4c66b0efdcd9
+    .claude/commands/ralph-loop.md: sha256:e560af6864dd5554ab26464cb526507e2b836117d468ca9c403fb6d5c674a900
+    .config/opencode/commands/cancel-ralph.md: sha256:942236042e91987d23f140703d9e81a097cc6c3d73fb09c32cbce3d358745ad8
+    .config/opencode/commands/help.md: sha256:414a3189d727186194aab7c8a60af93daa35c3d6995406a1697e4c66b0efdcd9
+    .config/opencode/commands/ralph-loop.md: sha256:e560af6864dd5554ab26464cb526507e2b836117d468ca9c403fb6d5c674a900
+    .cursor/commands/cancel-ralph.md: sha256:942236042e91987d23f140703d9e81a097cc6c3d73fb09c32cbce3d358745ad8
+    .cursor/commands/help.md: sha256:414a3189d727186194aab7c8a60af93daa35c3d6995406a1697e4c66b0efdcd9
+    .cursor/commands/ralph-loop.md: sha256:e560af6864dd5554ab26464cb526507e2b836117d468ca9c403fb6d5c674a900
+    .gemini/commands/cancel-ralph.toml: sha256:1bdb0a132597482657d88e6dca6f783eb85d58a92b491c312d620f7807f6435d
+    .gemini/commands/help.toml: sha256:c6c04acfb35a2b2f99b6e6972ed99f20be084a697bbedaeaff8b71f6647230a3
+    .gemini/commands/ralph-loop.toml: sha256:6f24c1c80458301677dd017941fe0b8071e2fbb9119ff8f6dc1deb3319e8f6fc
+  content_hash: sha256:505ef90f057b672ca418a7ba10da05be195d28b7089063beed4c614a08fb3c07
+- repo_url: anthropics/skills
+  host: github.com
+  resolved_commit: f458cee31a7577a47ba0c9a101976fa599385174
+  package_type: marketplace_plugin
+  deployed_files:
+  - .agents/skills/algorithmic-art
+  - .agents/skills/brand-guidelines
+  - .agents/skills/canvas-design
+  - .agents/skills/claude-api
+  - .agents/skills/doc-coauthoring
+  - .agents/skills/docx
+  - .agents/skills/frontend-design
+  - .agents/skills/internal-comms
+  - .agents/skills/mcp-builder
+  - .agents/skills/pdf
+  - .agents/skills/pptx
+  - .agents/skills/skill-creator
+  - .agents/skills/slack-gif-creator
+  - .agents/skills/theme-factory
+  - .agents/skills/web-artifacts-builder
+  - .agents/skills/webapp-testing
+  - .agents/skills/xlsx
+  - .claude/skills/algorithmic-art
+  - .claude/skills/brand-guidelines
+  - .claude/skills/canvas-design
+  - .claude/skills/claude-api
+  - .claude/skills/doc-coauthoring
+  - .claude/skills/docx
+  - .claude/skills/frontend-design
+  - .claude/skills/internal-comms
+  - .claude/skills/mcp-builder
+  - .claude/skills/pdf
+  - .claude/skills/pptx
+  - .claude/skills/skill-creator
+  - .claude/skills/slack-gif-creator
+  - .claude/skills/theme-factory
+  - .claude/skills/web-artifacts-builder
+  - .claude/skills/webapp-testing
+  - .claude/skills/xlsx
+  content_hash: sha256:91959dd47c219df6af45ed9d3f4be4302b00041e447254fdda0c51767b24e57b
+mcp_servers:
+- io.github.github/github-mcp-server
+mcp_configs:
+  io.github.github/github-mcp-server:
+    name: io.github.github/github-mcp-server
+    transport: http

--- a/modules/ai/apm/apm.yml
+++ b/modules/ai/apm/apm.yml
@@ -1,0 +1,17 @@
+name: dotfiles-apm
+version: 1.0.0
+description: APM project for dotfiles-apm
+author: nobv
+# Which agent platforms to deploy to:
+targets:
+  - claude
+
+dependencies:
+  apm:
+    - anthropics/skills
+    - anthropics/claude-plugins-official/plugins/ralph-loop
+  mcp:
+    - name: io.github.github/github-mcp-server
+      transport: http
+includes: auto
+scripts: {}

--- a/modules/ai/apm/apm.yml
+++ b/modules/ai/apm/apm.yml
@@ -1,6 +1,6 @@
-name: dotfiles-apm
-version: 1.0.0
-description: APM project for dotfiles-apm
+name: agent-config
+version: 0.0.1
+description: Declarative APM configuration for Claude Code skills, plugins, and MCP servers
 author: nobv
 # Which agent platforms to deploy to:
 targets:
@@ -10,6 +10,10 @@ dependencies:
   apm:
     - anthropics/skills
     - anthropics/claude-plugins-official/plugins/ralph-loop
+    - currents-dev/playwright-best-practices-skill
+    - shadcn-ui/ui/skills/shadcn
+    - vercel-labs/agent-skills/skills/react-best-practices
+    - vercel-labs/next-skills/skills/next-best-practices
   mcp:
     - name: io.github.github/github-mcp-server
       transport: http

--- a/modules/ai/apm/apm.yml
+++ b/modules/ai/apm/apm.yml
@@ -9,7 +9,6 @@ targets:
 dependencies:
   apm:
     - anthropics/skills
-    - anthropics/claude-plugins-official/plugins/ralph-loop
     - currents-dev/playwright-best-practices-skill
     - shadcn-ui/ui/skills/shadcn
     - vercel-labs/agent-skills/skills/react-best-practices

--- a/modules/ai/apm/default.nix
+++ b/modules/ai/apm/default.nix
@@ -22,33 +22,19 @@ in
     };
 
     home-manager.users.${username} =
-      { config, lib, ... }:
+      { config, ... }:
       {
+        # apm.yml is immutable (nix-store). apm.lock.yaml uses
+        # mkOutOfStoreSymlink so that `apm install -g` updates can flow
+        # back to the dotfiles repo for version control.
+        # Frozen install is wired into `just switch` (see Justfile), not
+        # home.activation, so rebuild and apm-sync stay separately
+        # observable.
         home.file = {
           ".apm/apm.yml".source = ./apm.yml;
           ".apm/apm.lock.yaml".source =
             config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/modules/ai/apm/apm.lock.yaml";
         };
-
-        # Frozen install on every rebuild: read-only, fails the rebuild if
-        # apm.yml and apm.lock.yaml drift. Requires `apm` (Homebrew) and
-        # `claude` (system) which are activated earlier in the rebuild.
-        # Run in a subshell so PATH extensions don't leak into later
-        # activation entries (linkGeneration relies on GNU `readlink -e`,
-        # which BSD readlink under /usr/bin does not support).
-        # /usr/bin: APM bundles GitPython, which shells out to `git`.
-        # /run/current-system/sw/bin: where nix-darwin places `claude`.
-        home.activation.apmSync = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-          (
-            PATH="$PATH:/opt/homebrew/bin:/run/current-system/sw/bin:/usr/bin:/bin"
-            if command -v apm >/dev/null && command -v git >/dev/null && command -v claude >/dev/null; then
-              $DRY_RUN_CMD apm install --frozen -g
-            else
-              echo "[apm] apm, claude, or git CLI not found; aborting." >&2
-              exit 1
-            fi
-          ) || exit 1
-        '';
       };
   };
 }

--- a/modules/ai/apm/default.nix
+++ b/modules/ai/apm/default.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  pkgs,
+  lib,
+  username,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.modules.ai.apm;
+  dotfilesPath = "/Users/${username}/.dotfiles";
+in
+{
+  options.modules.ai.apm.enable = mkEnableOption "Agent Package Manager (microsoft/apm)";
+
+  config = mkIf cfg.enable {
+    homebrew = mkIf (config.modules.system.homebrew.enable or false) {
+      taps = [ "microsoft/apm" ];
+      brews = [ "microsoft/apm/apm" ];
+    };
+
+    home-manager.users.${username} =
+      { config, lib, ... }:
+      {
+        home.file = {
+          ".apm/apm.yml".source = ./apm.yml;
+          ".apm/apm.lock.yaml".source =
+            config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/modules/ai/apm/apm.lock.yaml";
+        };
+
+        # Frozen install on every rebuild: read-only, fails the rebuild if
+        # apm.yml and apm.lock.yaml drift. Requires `apm` (Homebrew) and
+        # `claude` (system) which are activated earlier in the rebuild.
+        # Run in a subshell so PATH extensions don't leak into later
+        # activation entries (linkGeneration relies on GNU `readlink -e`,
+        # which BSD readlink under /usr/bin does not support).
+        # /usr/bin: APM bundles GitPython, which shells out to `git`.
+        # /run/current-system/sw/bin: where nix-darwin places `claude`.
+        home.activation.apmSync = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          (
+            PATH="$PATH:/opt/homebrew/bin:/run/current-system/sw/bin:/usr/bin:/bin"
+            if command -v apm >/dev/null && command -v git >/dev/null && command -v claude >/dev/null; then
+              $DRY_RUN_CMD apm install --frozen -g
+            else
+              echo "[apm] apm, claude, or git CLI not found; aborting." >&2
+              exit 1
+            fi
+          ) || exit 1
+        '';
+      };
+  };
+}

--- a/modules/ai/claude-code/settings.json
+++ b/modules/ai/claude-code/settings.json
@@ -86,7 +86,11 @@
     "padding": 0
   },
   "enabledPlugins": {
-    "claude-mem@thedotmack": true
+    "claude-mem@thedotmack": true,
+    "ralph-loop@claude-plugins-official": true,
+    "linear@claude-plugins-official": true,
+    "slack@claude-plugins-official": true,
+    "github@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "thedotmack": {

--- a/modules/ai/claude-code/settings.json
+++ b/modules/ai/claude-code/settings.json
@@ -47,8 +47,7 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh\""
           }
-        ],
-        "_apm_source": "ralph-loop"
+        ]
       }
     ],
     "UserPromptSubmit": [
@@ -87,17 +86,9 @@
     "padding": 0
   },
   "enabledPlugins": {
-    "claude-mem@thedotmack": true,
-    "document-skills@anthropic-agent-skills": true,
-    "example-skills@anthropic-agent-skills": true
+    "claude-mem@thedotmack": true
   },
   "extraKnownMarketplaces": {
-    "anthropic-agent-skills": {
-      "source": {
-        "source": "github",
-        "repo": "anthropics/skills"
-      }
-    },
     "thedotmack": {
       "source": {
         "source": "github",
@@ -106,7 +97,8 @@
     }
   },
   "language": "japanese",
-  "skipAutoPermissionPrompt": true,
   "theme": "dark-ansi",
-  "editorMode": "vim"
+  "editorMode": "vim",
+  "skipAutoPermissionPrompt": true,
+  "agentPushNotifEnabled": true
 }

--- a/modules/ai/claude-code/settings.json
+++ b/modules/ai/claude-code/settings.json
@@ -40,6 +40,15 @@
             "command": "workmux set-window-status done"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh\""
+          }
+        ],
+        "_apm_source": "ralph-loop"
       }
     ],
     "UserPromptSubmit": [


### PR DESCRIPTION
## What

Introduces [APM (Agent Package Manager) v0.13.0+](https://github.com/microsoft/apm) as a new module (`modules/ai/apm/`) to declaratively manage Claude Code plugins, skills, and MCP servers across machines.

## Why

- **Reproducibility**: lockfile-backed installs (`apm install --frozen -g`) fail loud on drift, matching Nix's declarative philosophy.
- **Multi-machine sync**: `apm.yml` + `apm.lock.yaml` are git-tracked and shared across macbook / macmini / work.
- **Unified management**: replaces ad-hoc per-tool installation with a single manifest.

## Key changes

### New module: `modules/ai/apm/`
- `default.nix` — installs `apm` via Homebrew (tap `microsoft/apm`), symlinks `apm.yml` (immutable, nix-store) and `apm.lock.yaml` (`mkOutOfStoreSymlink`, write-through).
- `apm.yml` (`name: agent-config`, `version: 0.0.1`) — declares:
  - `anthropics/skills` (Anthropic official skills bundle)
  - `anthropics/claude-plugins-official/plugins/ralph-loop`
  - `currents-dev/playwright-best-practices-skill`
  - `shadcn-ui/ui/skills/shadcn`
  - `vercel-labs/agent-skills/skills/react-best-practices`
  - `vercel-labs/next-skills/skills/next-best-practices`
  - MCP: `io.github.github/github-mcp-server` (HTTP transport)

### Integration into `just switch`
- `just switch` now runs `darwin-rebuild switch` followed by `apm install --frozen -g`.
- Frozen install is read-only; if the lockfile drifts the just task exits non-zero so the user is told to run `just apm-update` and commit.
- `home.activation` is intentionally NOT used so APM sync is observable separately from the Nix activation.

### Operational tasks (`Justfile`)
- `just apm-sync` — read-only sync (`apm install --frozen -g`)
- `just apm-update` — refresh deps and regenerate lockfile (commit the diff)
- `just apm-outdated` — show updates available
- `just apm-audit` — drift / integrity check

### Related cleanup
- `modules/ai/claude-code/settings.json`: removed redundant `enabledPlugins` / `extraKnownMarketplaces` for `anthropic-agent-skills` (now APM-managed). `claude-mem@thedotmack` stays declared because its plugin cannot be installed via APM.
- Picks up the `Stop` hook ralph-loop registers (tracked via `mkOutOfStoreSymlink`).

## Verification

- `nix build .#darwinConfigurations.macbook.system --no-link` — passes
- `darwin-rebuild switch --flake .#macbook` + `apm install --frozen -g` — both succeed; `apm` reports `Installed 6 APM dependencies and 1 MCP server` and `Lockfile presence verified`.

## Rollout plan

Enabled only on `macbook` in this PR. `macmini` and `work` will follow once `macbook` has soaked.

## Open follow-ups (out of scope)

- Pin unpinned dependencies (currently APM warns about unpinned skills).
- `io.github.github/github-mcp-server` is remote-SSE and fails to install for Codex CLI; harmless (configured for Claude/Gemini).
