### PR TITLE
feat(claude-code): isolate accounts via CLAUDE_CONFIG_DIR profiles + direnv helper

### DIFF
--- a/modules/ai/claude-code/default.nix
+++ b/modules/ai/claude-code/default.nix
@@ -25,6 +25,50 @@ in
         default.nix) to point at a machine-local (git-ignored) settings.json.
       '';
     };
+
+    profiles = mkOption {
+      default = { };
+      description = ''
+        Named Claude Code profiles. Each is an isolated data boundary via
+        CLAUDE_CONFIG_DIR (~/.config/claude/profiles/<name>) with its own history,
+        projects, and credentials. Which account backs a profile is chosen at
+        `/login` — the same private account can back several profiles (e.g. an
+        isolated client repo you must use a personal account for). On macOS each
+        config dir gets its own Keychain entry (the service name is namespaced by
+        a sha256 of the path), so profiles authenticate independently and can run
+        simultaneously.
+
+        Per-repo switching is usually better done with a `.envrc` containing
+        `use claude_profile <name>` (no entry here needed). Declare a profile here
+        only when you want a git-tracked, always-present alias + settings symlink.
+      '';
+      type = types.attrsOf (
+        types.submodule (
+          { name, ... }:
+          {
+            options = {
+              configDir = mkOption {
+                type = types.str;
+                default = "/Users/${username}/.config/claude/profiles/${name}";
+                description = "Absolute CLAUDE_CONFIG_DIR for this profile.";
+              };
+
+              settingsSource = mkOption {
+                type = types.str;
+                default = "modules/ai/claude-code/settings.json";
+                description = "Path to this profile's settings.json, relative to the repo root.";
+              };
+
+              aliasName = mkOption {
+                type = types.str;
+                default = "cc-${name}";
+                description = "Shell alias that launches Claude Code for this profile.";
+              };
+            };
+          }
+        )
+      );
+    };
   };
 
   config = mkIf cfg.enable {
@@ -40,15 +84,45 @@ in
 
     home-manager.users.${username} =
       { config, ... }:
+      let
+        mkSymlink = path: config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/${path}";
+        sharedClaudeMd = "modules/ai/claude-code/CLAUDE.md";
+        # home.file keys are relative to $HOME; profile config dirs live under it.
+        homeRel = profile: removePrefix "/Users/${username}/" profile.configDir;
+      in
       {
-        home.file = {
-          ".claude/settings.json".source =
-            config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/${cfg.settingsSource}";
-          ".claude/CLAUDE.md".source =
-            config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/modules/ai/claude-code/CLAUDE.md";
-          ".config/ccstatusline/settings.json".source =
-            config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/modules/ai/claude-code/ccstatusline-settings.json";
-        };
+        home.file = mkMerge (
+          [
+            {
+              ".claude/settings.json".source = mkSymlink cfg.settingsSource;
+              ".claude/CLAUDE.md".source = mkSymlink sharedClaudeMd;
+              ".config/ccstatusline/settings.json".source =
+                mkSymlink "modules/ai/claude-code/ccstatusline-settings.json";
+            }
+          ]
+          ++ (mapAttrsToList (_: profile: {
+            "${homeRel profile}/settings.json".source = mkSymlink profile.settingsSource;
+            "${homeRel profile}/CLAUDE.md".source = mkSymlink sharedClaudeMd;
+          }) cfg.profiles)
+        );
+
+        # `cc-<name>` launches Claude Code with that profile's isolated config dir.
+        programs.zsh.shellAliases = mapAttrs' (
+          _: profile: nameValuePair profile.aliasName "CLAUDE_CONFIG_DIR=${profile.configDir} claude"
+        ) cfg.profiles;
+
+        # direnv helper: a repo's `.envrc` with `use claude_profile <name>` isolates
+        # Claude Code data (history/projects/auth) under ~/.config/claude/profiles/<name>,
+        # while sharing the declarative settings.json / CLAUDE.md from the primary config.
+        programs.direnv.stdlib = mkAfter ''
+          use_claude_profile() {
+            local dir="''${XDG_CONFIG_HOME:-$HOME/.config}/claude/profiles/$1"
+            mkdir -p "$dir"
+            ln -sfn "$HOME/.claude/settings.json" "$dir/settings.json"
+            ln -sfn "$HOME/.claude/CLAUDE.md" "$dir/CLAUDE.md"
+            export CLAUDE_CONFIG_DIR="$dir"
+          }
+        '';
       };
   };
 }

--- a/modules/terminal/zsh/aliases.nix
+++ b/modules/terminal/zsh/aliases.nix
@@ -97,8 +97,6 @@
   ## home-manager
   reloadvim = "home-manager switch && vim";
 
-  #  claude = "env CLAUDE_CONFIG_DIR=$HOME/.claude claude";
-
   ##  nix {{{
   nix-repl = "nix repl '<nixpkgs>'";
   ## }}}


### PR DESCRIPTION
## What
- `modules.ai.claude-code.profiles`: CLAUDE_CONFIG_DIR で隔離した名前付きプロファイル（`~/.config/claude/profiles/<name>`）。git管理の固定枠用（任意）
- direnv ヘルパー `use_claude_profile <name>`: リポジトリの `.envrc` に1行書くと、その配下だけ別プロファイルに切替。クライアント名を dotfiles git に出さずに済む
- private は従来どおり素の `~/.claude`（デフォルト）。settings.json / CLAUDE.md は全プロファイル共有、履歴・認証のみ分離

## Why
private と仕事/クライアントでアカウント・履歴を分離したい。configDir はデータ境界であり、認証アカウントとは独立（同じ private アカウントを複数プロファイルで利用可、例: 先方都合で個人アカウントを使う隔離リポジトリ）

## Test
`nix build .#darwinConfigurations.macbook.system --dry-run` 成功